### PR TITLE
fix: deadlock fix

### DIFF
--- a/libsrc/pingpong/src/pingpong.cpp
+++ b/libsrc/pingpong/src/pingpong.cpp
@@ -10,6 +10,7 @@ void PingPong::ping()
         	cv_.notify_all();
         	cv_.wait(lock);
     	}
+	cv_.notify_all();
  	}
 
 void PingPong::pong()
@@ -22,4 +23,5 @@ void PingPong::pong()
         	cv_.notify_all();
         	cv_.wait(lock);
     	}
+	cv_.notify_all();
 	}


### PR DESCRIPTION
Главная проблема в том, что notify_all() размещается до переменной условия wait(). Из-за этого ожидающие потоки могут пропустить уведомления об остановке, поэтому происходит deadlock.